### PR TITLE
OBF2-13 Fix badge export and also image issue

### DIFF
--- a/config_legacy.php
+++ b/config_legacy.php
@@ -36,7 +36,7 @@ require_once(__DIR__ . '/classes/client.php');
 $context = context_system::instance();
 $msg = optional_param('msg', '', PARAM_TEXT);
 $action = optional_param('action', 'authenticate', PARAM_TEXT);
-$url = new moodle_url('/local/obf/config.php', $action != 'authenticate' ? array('action' => $action) : array());
+$url = new moodle_url('/local/obf/config_legacy.php', $action != 'authenticate' ? array('action' => $action) : array());
 $client = obf_client::get_instance();
 $badgesupport = file_exists($CFG->libdir . '/badgeslib.php');
 
@@ -162,6 +162,15 @@ switch ($action) {
                         $email = new obf_email();
                         $email->set_body($badge->message);
                         $email->set_subject($badge->messagesubject);
+                        
+                        $storage = get_file_storage();
+                        $imagefile = $storage->get_file(
+                            $context->id,
+                            'badges',
+                            'badgeimage',
+                            $badge->id,
+                            '/',
+                            'f1.png');
 
                         $obfbadge = obf_badge::get_instance_from_array(array(
                             'name' => $badge->name,
@@ -172,12 +181,7 @@ switch ($action) {
                             'tags' => array(),
                             'ctime' => null,
                             'description' => $badge->description,
-                            'image' => base64_encode(file_get_contents(
-                                moodle_url::make_pluginfile_url($badge->get_context()->id,
-                                    'badges',
-                                    'badgeimage',
-                                    $badge->id, '/',
-                                    'f1', false))),
+                            'image' => base64_encode($imagefile->get_content()),
                             'draft' => $data->makedrafts
                         ));
                         $obfbadge->set_email($email);

--- a/settings.php
+++ b/settings.php
@@ -59,7 +59,7 @@ if ($hasobfconfig) {
 
     // Badge export settings.
     $export = new admin_externalpage('obfexportbadges', get_string('exportsettings', 'local_obf'),
-        new moodle_url('/local/obf/config.php', array('action' => 'exportbadges')), 'local/obf:configure');
+        new moodle_url('/local/obf/config_legacy.php', array('action' => 'exportbadges')), 'local/obf:configure');
     $ADMIN->add('obf', $export);
 
     $ADMIN->add('obf', $badgelist);


### PR DESCRIPTION
- Fix the problem related to the export of badges which no longer worked, it seems that the link was incorrect because the export action is in the file "config_legacy.php".
- The image was not exported with the badge so I also solved this problem.